### PR TITLE
Added availability

### DIFF
--- a/site/pages/rest-api/api/baseline.md
+++ b/site/pages/rest-api/api/baseline.md
@@ -2,6 +2,7 @@
 title: Baseline
 ---
 
+Available starting from IBM BigFix version 9.5.5
 
 {% restapi "/api/baselines/{site type}/{site name}", "GET", "Lists all baselines in a site." %}
 


### PR DESCRIPTION
I added "Available starting from IBM BigFix version 9.5.5" as requested by RTC defect https://rtc3srv1.tivlab.raleigh.ibm.com:9443/ccm/web/projects/BigFix%20Platform#action=com.ibm.team.workitem.viewWorkItem&id=146032 

Please ensure that this change is ported also on the internal beta site. Thanks. Ciao