### PR TITLE
Add timeout to Pause While action script command

### DIFF
--- a/site/pages/action-script/reference/flow-control/pause-while.md
+++ b/site/pages/action-script/reference/flow-control/pause-while.md
@@ -22,8 +22,16 @@ Pause action script evaluation while `updater.exe` is running.
 pause while {exists running application "updater.exe"}
 ```
 
+Pause action script evaulation while `updater.exe` is running, with a 5 minute timeout.
+
+```actionscript
+parameter "PauseTimer1" = "{now}"
+pause while {(exists running application "updater.exe") AND (now < ((parameter "PauseTimer1" of action as time) + (5 * minute)))}
+```
+
 Pause action script evaluation while the file `C:\result.txt` does not exist.
 
 ```actionscript
 pause while {not exists file "C:\result.txt"}
 ```
+


### PR DESCRIPTION
Since Pause While does not timeout on it's own, not using a timeout can hang the BigFix agent in an action that never ends.
Added example to include a timeout.