### PR TITLE
Descriptions for core_count of and thread_count of

### DIFF
--- a/site/pages/relevance/_reference/docs/dmi-processor_information.md
+++ b/site/pages/relevance/_reference/docs/dmi-processor_information.md
@@ -8,7 +8,7 @@ No documentation exists.
 
 # core_count of &lt;dmi processor_information&gt; : integer
 
-No documentation exists.
+The number of cores per socket.
 
 # core_enabled of &lt;dmi processor_information&gt; : integer
 
@@ -92,7 +92,7 @@ No documentation exists.
 
 # thread_count of &lt;dmi processor_information&gt; : integer
 
-No documentation exists.
+The number of threads per socket.
 
 # voltage of &lt;dmi processor_information&gt; : integer
 


### PR DESCRIPTION
Add the following description to core_count of:
The number of cores per socket.
Add the following description to thread_count of:
The number of threads per socket.